### PR TITLE
Develop

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4    
+    - uses: actions/checkout@v5    
       with:
         fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
@@ -35,7 +35,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,38 +1,31 @@
 name: "Prerelease"
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  push:
+    tags:
+      - "v*"
 
 permissions:
-  contents: write
+  contents: read
   packages: write
-  pull-requests: read
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  
-  PROJECT_PATH: 'src/Funcfy/Funcfy.csproj'
+  PROJECT_PATH: "src/Funcfy/Funcfy.csproj"
   PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/output
-
-  GITHUB_USER: leo-oliveira-eng
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_FEED: https://nuget.pkg.github.com/leo-oliveira-eng/
 
 jobs:
   pack:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout  
-      uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v5
       with:
-        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        ref: ${{ github.ref }}
         fetch-depth: 0
 
     - name: Cache NuGet packages
@@ -54,40 +47,14 @@ jobs:
     - name: build
       run: dotnet build -c Release --no-restore
 
-    - name: Determine version bump
-      id: bump
-      shell: bash
-      run: |
-        labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
-        bump="patch"
-
-        if [[ " $labels " == *" major "* ]]; then
-          bump="major"
-        elif [[ " $labels " == *" minor "* ]]; then
-          bump="minor"
-        fi
-
-        echo "bump=$bump" >> "$GITHUB_OUTPUT"
-
-    - name: Create SemVer tag
-      id: semver
-      uses: leo-oliveira-eng/tag-semver-action@0.1.2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        allowed-base-branches: main
-        tag-prefix: v
-        major-label: major
-        minor-label: minor
-        default-bump: ${{ steps.bump.outputs.bump }}
-
     - name: Determine package version
       id: version
       shell: bash
       run: |
-        tag="${{ steps.semver.outputs.next-tag }}"
+        tag="${GITHUB_REF_NAME}"
 
         if [[ -z "$tag" ]]; then
-          echo "Unable to determine the release tag from the SemVer action output." >&2
+          echo "Unable to determine the tag name from the workflow context." >&2
           exit 1
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag-main.yml
+++ b/.github/workflows/tag-main.yml
@@ -1,0 +1,54 @@
+name: "Tag Main"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: tag-main-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout merged commit
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        fetch-depth: 0
+
+    - name: Determine version bump
+      id: bump
+      shell: bash
+      run: |
+        labels="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+        bump="patch"
+
+        if [[ " $labels " == *" major "* ]]; then
+          bump="major"
+        elif [[ " $labels " == *" minor "* ]]; then
+          bump="minor"
+        fi
+
+        echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+    - name: Create SemVer tag
+      id: semver
+      uses: leo-oliveira-eng/tag-semver-action@0.1.2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-base-branches: main
+        tag-prefix: v
+        major-label: major
+        minor-label: minor
+        default-bump: ${{ steps.bump.outputs.bump }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `funcfy` should be documented in this file.
+
+This project follows a lightweight changelog format:
+
+- keep an `Unreleased` section at the top
+- move entries into a versioned section when publishing a release
+- group entries under `Added`, `Changed`, `Fixed`, and `Documentation`
+
+## Unreleased
+
+### Added
+
+- Integration-style ASP.NET Core coverage for `Result.ToActionResult()` execution.
+- Additional service-layer and controller-layer examples for `Maybe<T>`, `Result`, and ASP.NET Core usage.
+
+### Changed
+
+- Replaced legacy ASP.NET Core MVC package references with the .NET 8 shared framework reference.
+- Updated documentation navigation so examples, roadmap, and release notes are easier to find.
+
+### Documentation
+
+- Added `CHANGELOG.md` and linked it from the root README and docs index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project follows a lightweight changelog format:
 
 ## Unreleased
 
+## 0.3.0 - 2026-04-08
+
 ### Added
 
 - Introduced `Either<TLeft, TRight>` as a first-class right-biased monad with `Left`/`Right` factories, `Match`, `Map`, `MapLeft`, `Bind`, recovery helpers, and side-effect helpers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows a lightweight changelog format:
 
 ### Added
 
+- Introduced `Either<TLeft, TRight>` as a first-class right-biased monad with `Left`/`Right` factories, `Match`, `Map`, `MapLeft`, `Bind`, recovery helpers, and side-effect helpers.
+- Added `Either` conversion helpers for `Maybe<T>` and one-way conversion to `Result<T>`.
 - Integration-style ASP.NET Core coverage for `Result.ToActionResult()` execution.
 - Additional service-layer and controller-layer examples for `Maybe<T>`, `Result`, and ASP.NET Core usage.
 
@@ -20,6 +22,11 @@ This project follows a lightweight changelog format:
 - Replaced legacy ASP.NET Core MVC package references with the .NET 8 shared framework reference.
 - Updated documentation navigation so examples, roadmap, and release notes are easier to find.
 
+### Fixed
+
+- Added automated coverage for `Either` branch equality, monad laws, lazy fallback behavior, and delegate guard clauses.
+
 ### Documentation
 
 - Added `CHANGELOG.md` and linked it from the root README and docs index.
+- Added `Either` documentation and surfaced it in the root README and docs index.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Functional programming can make application code easier to reason about when it 
 In practice, this can help you:
 
 - reduce null-related checks and make missing values explicit with `Maybe<T>`
+- make recoverable failure explicit with `Either<TLeft, TRight>`
 - represent operation outcomes without relying only on exceptions for expected business cases
 - keep success and failure handling close to the code path through `Match`
 - carry structured messages that are easier to translate into API responses
@@ -25,8 +26,9 @@ In practice, this can help you:
 ## What It Includes
 
 - `Maybe<T>` for optional values
+- `Either<TLeft, TRight>` for right-biased success/failure composition
 - `Result` and `Result<T>` for success/failure flows with typed messages
-- `Match` APIs for `Maybe<T>`, `Result`, and `Result<T>`
+- `Match` APIs for `Maybe<T>`, `Either<TLeft, TRight>`, `Result`, and `Result<T>`
 - message helpers and typed error categories
 - ASP.NET Core helpers to convert results into `IActionResult`
 
@@ -42,6 +44,7 @@ For detailed guides, API references, examples, and more, explore our documentati
 
 - **[Getting Started](./docs/README.md)** - Quick start guide to using funcfy in your projects
 - **[Maybe](./docs/maybe.md)** - Optional-value patterns with service and controller examples
+- **[Either](./docs/either.md)** - Explicit recoverable failures with right-biased composition
 - **[Result](./docs/result.md)** - Success/failure flows, messages, and extension helpers
 - **[ASP.NET Core](./docs/aspnetcore.md)** - Controller translation patterns and HTTP mapping
 - **[API Reference](./docs/README.md)** - Complete documentation of all types, methods, and extensions

--- a/README.md
+++ b/README.md
@@ -1,124 +1,54 @@
 <p align="center">
-      <img  
-        alt="funcfy - A lightweight, batteries-included functional programming toolkit for C#/.NET." 
-        src="https://github.com/leo-oliveira-eng/funcfy/blob/main/images/logo.png"
-        height="400px"
-      />
+  <img
+    alt="funcfy - A lightweight, batteries-included functional programming toolkit for C#/.NET."
+    src="https://github.com/leo-oliveira-eng/funcfy/blob/main/images/logo.png"
+    height="320px"
+  />
 </p>
 
 # funcfy
 
 A lightweight, batteries-included functional programming toolkit for C#/.NET.
 
-## Features
+## Why Funcfy
 
-📋 Currying & partial application  
-🔄 Either, Maybe, Result types  
-📋 Functor, Applicative, Monad interfaces  
-📋 Lens utilities, compose, pipe
+Functional programming can make application code easier to reason about when it is used in the right places. `funcfy` is not trying to force a pure functional style across an entire .NET codebase. The goal is to provide a small set of practical tools that help developers model optional values, success/failure flows, and explicit branching in a clear and predictable way.
 
-## Getting Started
+In practice, this can help you:
 
-Install via NuGet:
+- reduce null-related checks and make missing values explicit with `Maybe<T>`
+- represent operation outcomes without relying only on exceptions for expected business cases
+- keep success and failure handling close to the code path through `Match`
+- carry structured messages that are easier to translate into API responses
+- make service and application-layer code more expressive while staying familiar to C# developers
+
+## What It Includes
+
+- `Maybe<T>` for optional values
+- `Result` and `Result<T>` for success/failure flows with typed messages
+- `Match` APIs for `Maybe<T>`, `Result`, and `Result<T>`
+- message helpers and typed error categories
+- ASP.NET Core helpers to convert results into `IActionResult`
+
+## Install
 
 ```bash
-dotnet add package Funcfy --version 0.1.0-alpha
+dotnet add package Funcfy
 ```
 
-Import the core namespace:
+## Documentation
 
-```csharp
-using Funcfy;
-```
+For detailed guides, API references, examples, and more, explore our documentation:
 
-Example currying:
+- **[Getting Started](./docs/README.md)** - Quick start guide to using funcfy in your projects
+- **[API Reference](./docs/README.md)** - Complete documentation of all types, methods, and extensions
+- **[Roadmap](./docs/roadmap.md)** - Upcoming features and planned improvements
 
-```csharp
-var add = Func.Curry((int x, int y) => x + y);
-var add5 = add(5);
-Console.WriteLine(add5(3));  // 8
-```
-
-## Using Maybe<T>
-
-The `Maybe<T>` type expresses optional values explicitly, avoiding null-reference surprises. Example:
-
-
-  ```csharp
-    public class RepositoryAsync<Entity> : SpecificMethods<Entity>, IRepositoryAsync<Entity>
-    {
-    ...
-
-    public async Task<Maybe<Entity>> FindAsync(int id)
-        => await DbSet.FirstOrDefaultAsync(entity => entity.Id.Equals(id));
-        
-    ...
-    }
-        
-  ```
-
-The developer can act as follows when receiving the response:
-
-  ```csharp
-
-    ...
-
-        var entity = await EntityRepository.FindAsync(entityId);
-
-        if (entity.IsEmpty)
-            return response.WithError("Not found");
-
-    ...
-
-  ```
-
-### Creating Instances
-
-- **Empty** (no value):
-
-  ```csharp
-  var empty = Maybe<int>.Empty();          // IsFull == false, IsEmpty == true
-  ```
-
-- **Full** (with a value):
-
-  ```csharp
-  var full = Maybe<string>.Full("hello");  // IsFull == true, Value == "hello"
-  Maybe<int> also = 42;                      // implicit conversion wraps 42 as Full
-  ```
-
-### Inspecting Values
-
-Use `IsFull` or `IsEmpty` before accessing `Value`:
-
-```csharp
-if (full.IsFull)
-{
-    Console.WriteLine(full.Value);
-}
-else
-{
-    Console.WriteLine("No value present.");
-}
-```
-
-### Conversion Operators
-
-Thanks to the implicit operator, you can assign raw values directly:
-
-```csharp
-Maybe<double> pi = 3.14;  // equivalent to Maybe<double>.Full(3.14)
-```
-
-> ⚠️ **Important:** Accessing `Value` when `IsEmpty` is `true` returns `null` for reference types or the default for value types. Always check `IsFull` first.
+Whether you're a developer looking to use funcfy or a contributor wanting to understand the codebase, our docs have you covered.
 
 ## Contributing
 
-1. Fork the repo  
-2. Create a feature branch (`git checkout -b feature/foo`)  
-3. Commit changes (`git commit -m 'feat: add foo'`)  
-4. Push to your branch (`git push origin feature/foo`)  
-5. Open a Pull Request to develop branch
-
----
-
+1. Fork the repository.
+2. Create a feature branch from `develop`.
+3. Commit your changes using a clear conventional-style message.
+4. Push your branch and open a pull request to `develop`.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ dotnet add package Funcfy
 For detailed guides, API references, examples, and more, explore our documentation:
 
 - **[Getting Started](./docs/README.md)** - Quick start guide to using funcfy in your projects
+- **[Maybe](./docs/maybe.md)** - Optional-value patterns with service and controller examples
+- **[Result](./docs/result.md)** - Success/failure flows, messages, and extension helpers
+- **[ASP.NET Core](./docs/aspnetcore.md)** - Controller translation patterns and HTTP mapping
 - **[API Reference](./docs/README.md)** - Complete documentation of all types, methods, and extensions
 - **[Roadmap](./docs/roadmap.md)** - Upcoming features and planned improvements
+- **[Changelog](./CHANGELOG.md)** - Release notes and noteworthy package/runtime changes
 
 Whether you're a developer looking to use funcfy or a contributor wanting to understand the codebase, our docs have you covered.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,99 @@
+# funcfy Documentation
+
+## Overview
+
+`funcfy` is a small .NET library focused on practical functional-style primitives for application code.
+
+Today the project is centered on:
+
+- `Maybe<T>` for optional values
+- `Result` and `Result<T>` for operation outcomes
+- `Message` and `MessageType` for structured success, warning, and error information
+- extension helpers for building and combining results
+- ASP.NET Core integration through `IActionResult` conversion helpers
+
+## Guides
+
+- [Maybe](./maybe.md)
+- [Result](./result.md)
+- [ASP.NET Core](./aspnetcore.md)
+
+## Current API Surface
+
+### `Maybe<T>`
+
+Use `Maybe<T>` when a value may or may not exist.
+
+Main capabilities:
+
+- `Create`, `Empty`, and `Full`
+- `IsEmpty`, `IsFull`, and `Value`
+- implicit conversion from `T` to `Maybe<T>`
+- `Match` for branching without manual null-like checks
+
+Example:
+
+```csharp
+Maybe<int> maybe = 42;
+
+var text = maybe.Match(
+    onFull: value => $"Value: {value}",
+    onEmpty: () => "No value"
+);
+```
+
+### `Result`
+
+Use `Result` when an operation has no return value but still needs to communicate success, warnings, or failure.
+
+Main capabilities:
+
+- `Create`, `Success`, and `Failure`
+- `Messages`, `Failed`, and `IsSuccessful`
+- `Match` for success/failure branching
+- fluent message helpers such as `WithWarning`, `WithBadRequest`, and `WithServerError`
+- `ToActionResult` and `ToErrorActionResult`
+
+Example:
+
+```csharp
+var result = Result.Success()
+    .WithInformation("User created");
+
+var status = result.Match(
+    onSuccess: () => "ok",
+    onFailure: messages => $"failed: {messages[0].Content}"
+);
+```
+
+### `Result<T>`
+
+Use `Result<T>` when an operation may return a value and may also carry messages.
+
+Main capabilities:
+
+- `Create`, `Success`, `Failure`, and `SetValue`
+- `Data` as `Maybe<T>`
+- success/failure `Match` where the success branch receives `Maybe<T>`
+- fluent typed message helpers inherited through result extensions
+
+Example:
+
+```csharp
+var result = Result<string>.Success("funcfy");
+
+var output = result.Match(
+    onSuccess: maybe => maybe.Match(
+        onFull: value => value.ToUpperInvariant(),
+        onEmpty: () => "EMPTY"
+    ),
+    onFailure: messages => messages[0].Content
+);
+```
+
+
+## Roadmap
+
+The roadmap is maintained separately here:
+
+- [Roadmap](./roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 Today the project is centered on:
 
 - `Maybe<T>` for optional values
+- `Either<TLeft, TRight>` for recoverable success/failure composition
 - `Result` and `Result<T>` for operation outcomes
 - `Message` and `MessageType` for structured success, warning, and error information
 - extension helpers for building and combining results
@@ -15,6 +16,7 @@ Today the project is centered on:
 ## Guides
 
 - [Maybe](./maybe.md)
+- [Either](./either.md)
 - [Result](./result.md)
 - [ASP.NET Core](./aspnetcore.md)
 - [Roadmap](./roadmap.md)
@@ -23,6 +25,7 @@ Today the project is centered on:
 If you are looking for concrete usage patterns first, start with:
 
 - [Maybe service/controller examples](./maybe.md#example-service-layer)
+- [Either validation and chaining examples](./either.md#validation-example)
 - [Result service examples and extension helpers](./result.md#example-result-extension-helpers-in-a-service)
 - [ASP.NET Core controller examples](./aspnetcore.md#example-controller-with-toactionresult)
 
@@ -71,6 +74,32 @@ var result = Result.Success()
 var status = result.Match(
     onSuccess: () => "ok",
     onFailure: messages => $"failed: {messages[0].Content}"
+);
+```
+
+### `Either<TLeft, TRight>`
+
+Use `Either<TLeft, TRight>` when an operation can fail in a recoverable, typed way and you want right-biased composition.
+
+Main capabilities:
+
+- `Either.Left` and `Either.Right`
+- `IsLeft` and `IsRight`
+- `Match`
+- `Map`, `MapLeft`, and `Bind`
+- `GetOrElse` and `OrElse`
+- `Tap` and `TapLeft`
+- conversion helpers to `Maybe<T>` and `Result<T>`
+
+Example:
+
+```csharp
+var either = Either.Right<string, int>(21)
+    .Map(value => value * 2);
+
+var text = either.Match(
+    onLeft: error => $"Error: {error}",
+    onRight: value => $"Value: {value}"
 );
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,14 @@ Today the project is centered on:
 - [Maybe](./maybe.md)
 - [Result](./result.md)
 - [ASP.NET Core](./aspnetcore.md)
+- [Roadmap](./roadmap.md)
+- [Changelog](../CHANGELOG.md)
+
+If you are looking for concrete usage patterns first, start with:
+
+- [Maybe service/controller examples](./maybe.md#example-service-layer)
+- [Result service examples and extension helpers](./result.md#example-result-extension-helpers-in-a-service)
+- [ASP.NET Core controller examples](./aspnetcore.md#example-controller-with-toactionresult)
 
 ## Current API Surface
 

--- a/docs/aspnetcore.md
+++ b/docs/aspnetcore.md
@@ -1,0 +1,217 @@
+# ASP.NET Core Integration
+
+## Why this matters
+
+A lot of application code eventually needs to translate domain or service outcomes into HTTP responses.
+
+Without a result abstraction, controllers often become full of repetitive branching:
+
+- if it failed, return `BadRequest`
+- if it was unauthorized, return `Unauthorized`
+- if it was not found, return `NotFound`
+- otherwise return `Ok`
+
+That logic is necessary, but it can quickly take over the controller and make the real intent harder to see.
+
+`funcfy` helps by letting you carry outcome information through the service layer and convert it near the HTTP boundary.
+
+## The theory, kept practical
+
+A controller is an adapter.
+
+Its job is usually not to invent business outcome logic, but to translate application outcomes into HTTP responses.
+
+When your service returns a structured `Result`, the controller can stay thin:
+
+- service decides the outcome
+- controller translates the outcome to HTTP
+
+That separation gives you:
+
+- cleaner controllers
+- more reusable service code
+- more consistent HTTP mapping
+
+## What `funcfy` provides today
+
+`EmptyResultExtensions` includes:
+
+- `ToActionResult()`
+- `ToErrorActionResult()`
+
+These are currently defined for the non-generic `Result` type.
+
+## How HTTP mapping works
+
+`ToErrorActionResult()` maps the first error message type to an ASP.NET Core result.
+
+Current mappings include:
+
+- `BusinessError` → `422 Unprocessable Entity`
+- `BadRequest` → `400 Bad Request`
+- `Unauthorized` → `401 Unauthorized`
+- `Forbidden` → `403 Forbidden`
+- `NotFound` → `404 Not Found`
+- `Conflict` → `409 Conflict`
+- `ServerError` → `500 Internal Server Error`
+- `ServiceUnavailable` → `503 Service Unavailable`
+
+`ToActionResult()` behaves like this:
+
+- failed result → `ToErrorActionResult()`
+- successful result with messages → `200 OK`
+- successful result with no messages → `204 No Content`
+
+## Example: controller without helpers
+
+```csharp
+[HttpPost]
+public async Task<IActionResult> Create(CreateCustomerCommand command)
+{
+    var result = await _service.CreateAsync(command);
+
+    if (result.Failed)
+    {
+        var type = result.Messages[0].Type;
+
+        if (type == MessageType.BadRequest)
+            return BadRequest(result);
+
+        if (type == MessageType.NotFound)
+            return NotFound(result);
+
+        return StatusCode(500, result);
+    }
+
+    if (result.Messages.Any())
+        return Ok(result);
+
+    return NoContent();
+}
+```
+
+This works, but the controller now owns a lot of translation noise.
+
+## Example: controller with `ToActionResult()`
+
+```csharp
+[HttpPost]
+public async Task<IActionResult> Create(CreateCustomerCommand command)
+{
+    var result = await _service.CreateAsync(command);
+    return result.ToActionResult();
+}
+```
+
+That is a lot easier to scan.
+
+## Advantages in practice
+
+### 1. Thin controllers
+
+Controllers can focus on:
+
+- receiving input
+- calling the application layer
+- returning translated output
+
+instead of re-implementing response mapping everywhere.
+
+### 2. Consistent error handling
+
+If the team uses result message types consistently, response translation becomes standardized.
+
+That helps avoid situations where one controller returns `400` and another returns `422` for the same kind of business rule failure.
+
+### 3. Better service/controller separation
+
+The service can stay HTTP-agnostic:
+
+```csharp
+public async Task<Result> CreateAsync(CreateCustomerCommand command)
+{
+    if (string.IsNullOrWhiteSpace(command.Name))
+        return Result.Failure(Message.Create("Name is required", MessageType.BadRequest));
+
+    // business logic here
+    return Result.Success().WithInformation("Customer created");
+}
+```
+
+The controller becomes a thin translation layer:
+
+```csharp
+[HttpPost]
+public async Task<IActionResult> Create(CreateCustomerCommand command)
+{
+    var result = await _service.CreateAsync(command);
+    return result.ToActionResult();
+}
+```
+
+## Example: richer outcomes from the service layer
+
+```csharp
+public async Task<Result> DisableUserAsync(Guid id)
+{
+    var user = await _repository.FindByIdAsync(id);
+
+    if (user.IsEmpty)
+        return Result.Failure(Message.Create("User not found", MessageType.NotFound));
+
+    if (!await _authorization.CanDisableAsync(id))
+        return Result.Failure(Message.Create("Operation not allowed", MessageType.Forbidden));
+
+    await _repository.DisableAsync(id);
+
+    return Result.Success()
+        .WithInformation("User disabled");
+}
+```
+
+Controller:
+
+```csharp
+[HttpPost("{id:guid}/disable")]
+public async Task<IActionResult> Disable(Guid id)
+{
+    var result = await _service.DisableUserAsync(id);
+    return result.ToActionResult();
+}
+```
+
+This keeps the important rules in the application layer while still producing useful HTTP responses.
+
+## Current limitation
+
+The built-in action-result helpers currently focus on non-generic `Result`.
+
+That still gives you a strong pattern:
+
+- use `Result<T>` in services where data matters
+- translate into a non-generic `Result` when the HTTP response is command-oriented
+- or manually shape the HTTP response at the controller boundary when you need payload-specific output
+
+The roadmap already points toward richer HTTP integration for generic results.
+
+## Recommended usage pattern
+
+For ASP.NET Core applications, a practical pattern is:
+
+1. use `Maybe<T>` for optional lookups
+2. use `Result` or `Result<T>` in application services
+3. keep HTTP translation at the controller edge
+4. standardize `MessageType` usage across the application
+
+That gives you the benefits of functional-style modeling without making the controller layer harder to work with.
+
+## Summary
+
+The ASP.NET Core integration is useful because it turns structured application outcomes into consistent HTTP responses with very little controller code.
+
+Its main practical advantages are:
+
+- thinner controllers
+- more explicit service outcomes
+- more consistent response mapping
+- better separation between business logic and HTTP translation

--- a/docs/aspnetcore.md
+++ b/docs/aspnetcore.md
@@ -105,6 +105,28 @@ public async Task<IActionResult> Create(CreateCustomerCommand command)
 
 That is a lot easier to scan.
 
+## Example: query controller with `Result<T>`
+
+`ToActionResult()` currently targets non-generic `Result`, but `Result<T>` still fits query endpoints when you shape the payload explicitly:
+
+```csharp
+[HttpGet("{id:guid}")]
+public async Task<IActionResult> GetById(Guid id)
+{
+    var result = await _service.GetCustomerAsync(id);
+
+    return result.Match<IActionResult>(
+        onSuccess: customer => customer.Match<IActionResult>(
+            onFull: value => Ok(value),
+            onEmpty: () => NoContent()
+        ),
+        onFailure: messages => Result.Failure(messages[0]).ToErrorActionResult()
+    );
+}
+```
+
+That keeps the service expressive while still returning conventional HTTP responses.
+
 ## Advantages in practice
 
 ### 1. Thin controllers

--- a/docs/either.md
+++ b/docs/either.md
@@ -1,0 +1,252 @@
+# Either
+
+## What problem `Either<TLeft, TRight>` solves
+
+Some operations can fail in ways that are expected, meaningful, and recoverable.
+
+Examples:
+
+- validation can fail
+- parsing can fail
+- authorization checks can fail
+- domain rules can reject input
+
+Using exceptions for those outcomes can hide the failure path from the method signature.
+
+`Either<TLeft, TRight>` makes that branch explicit.
+
+Instead of returning only a success value and relying on exceptions for expected problems, the API says:
+
+- `Left<TLeft>` contains the failure value
+- `Right<TRight>` contains the success value
+
+In `funcfy`, `Either` is right-biased. That means mapping and binding continue through the `Right` branch and short-circuit on `Left`.
+
+## The theory, in practical terms
+
+`Either<TLeft, TRight>` is a common functional abstraction for computations with two possible outcomes.
+
+The important practical ideas are:
+
+- failure is explicit in the return type
+- `Right` is treated as the successful branch
+- `Map` transforms only the success value
+- `Bind` chains computations that also return `Either`
+- once a computation becomes `Left`, later binds do not run
+- `Match` forces the caller to handle both branches
+
+This makes `Either` a strong fit for recoverable domain and application errors.
+
+It is not intended to replace exceptions for programmer mistakes or unrecoverable system failures.
+
+## Main API
+
+`Either<TLeft, TRight>` currently provides:
+
+- `Either.Left<L, R>(value)`
+- `Either.Right<L, R>(value)`
+- `IsLeft`
+- `IsRight`
+- `Match`
+- `Map`
+- `MapLeft`
+- `Bind`
+- `GetOrElse`
+- `OrElse`
+- `Tap`
+- `TapLeft`
+- `ToMaybe`
+- `ToResult`
+
+## Creating values
+
+### Left
+
+```csharp
+var either = Either.Left<string, int>("validation failed");
+
+Console.WriteLine(either.IsLeft);  // true
+Console.WriteLine(either.IsRight); // false
+```
+
+### Right
+
+```csharp
+var either = Either.Right<string, int>(42);
+
+Console.WriteLine(either.IsLeft);  // false
+Console.WriteLine(either.IsRight); // true
+```
+
+## Branching with `Match`
+
+`Match` is the canonical way to handle both branches explicitly.
+
+```csharp
+var either = Either.Right<string, int>(21);
+
+var text = either.Match(
+    onLeft: error => $"Error: {error}",
+    onRight: value => $"Value: {value * 2}"
+);
+```
+
+Because both handlers are required, the caller must deal with success and failure in one place.
+
+## Mapping success with `Map`
+
+Because `Either` is right-biased, `Map` only transforms the `Right` branch:
+
+```csharp
+var result = Either.Right<string, int>(21)
+    .Map(value => value * 2);
+```
+
+If the value is already `Left`, `Map` does nothing and preserves the failure branch.
+
+## Chaining with `Bind`
+
+`Bind` is what makes `Either` a monad in practice.
+
+It lets you sequence computations that each return `Either`.
+
+```csharp
+Either<string, int> Parse(string input)
+    => int.TryParse(input, out var value)
+        ? Either.Right<string, int>(value)
+        : Either.Left<string, int>("Input is not a valid integer");
+
+Either<string, int> EnsurePositive(int value)
+    => value > 0
+        ? Either.Right<string, int>(value)
+        : Either.Left<string, int>("Value must be positive");
+
+var result = Parse("10")
+    .Bind(EnsurePositive)
+    .Map(value => value * 2);
+```
+
+If `Parse` fails, `EnsurePositive` is never called.
+
+That short-circuiting behavior is the key semantic guarantee.
+
+## Validation example
+
+```csharp
+Either<string, string> ValidateName(string? name)
+{
+    if (string.IsNullOrWhiteSpace(name))
+        return Either.Left<string, string>("Name is required");
+
+    if (name.Length > 100)
+        return Either.Left<string, string>("Name is too long");
+
+    return Either.Right<string, string>(name.Trim());
+}
+```
+
+Usage:
+
+```csharp
+var response = ValidateName(input).Match(
+    onLeft: error => $"Validation failed: {error}",
+    onRight: validName => $"Accepted: {validName}"
+);
+```
+
+## Recovery helpers
+
+`GetOrElse` and `OrElse` let you provide fallbacks without losing the explicit branch model.
+
+```csharp
+var fallbackValue = Either.Left<string, int>("missing")
+    .GetOrElse(error => error.Length);
+
+var recovered = Either.Left<string, int>("missing")
+    .OrElse(error => Either.Right<string, int>(error.Length));
+```
+
+The delegate-based overloads are usually the better choice when the fallback depends on the left value or is expensive to compute.
+
+## Side effects with `Tap`
+
+`Tap` and `TapLeft` are useful when you need logging, metrics, or tracing without changing the value.
+
+```csharp
+var result = Either.Right<string, int>(42)
+    .Tap(value => Console.WriteLine($"Success: {value}"))
+    .TapLeft(error => Console.WriteLine($"Failure: {error}"));
+```
+
+These methods are observational only and return the original `Either`.
+
+## Conversions
+
+### `Maybe<T>` to `Either<TLeft, TRight>`
+
+```csharp
+Maybe<int> maybe = 42;
+
+var either = maybe.ToEither(() => "No value");
+```
+
+### `Either<TLeft, TRight>` to `Maybe<TRight>`
+
+```csharp
+var maybe = Either.Right<string, int>(42).ToMaybe();
+```
+
+### `Either<TLeft, TRight>` to `Result<TRight>`
+
+```csharp
+var result = Either.Left<string, int>("Customer not found")
+    .ToResult(error => Message.Create(error, MessageType.NotFound));
+```
+
+This conversion is intentionally one-way in v1. `Result<T>` can represent success without a value, which does not map cleanly back into `Either`.
+
+## When to use `Either` vs exceptions
+
+Use `Either<TLeft, TRight>` when:
+
+- failure is expected and recoverable
+- the failure value is part of the domain or application flow
+- you want success and failure visible in the method signature
+- you want to compose several recoverable steps with `Bind`
+
+Prefer exceptions when:
+
+- the failure is not part of the normal contract
+- the problem is a programmer bug
+- the system is in an invalid or unrecoverable state
+
+## When to use `Either`, `Maybe`, or `Result`
+
+Use `Maybe<T>` when:
+
+- the main question is whether a value exists
+- absence is normal
+- you do not need failure details
+
+Use `Either<TLeft, TRight>` when:
+
+- you need an explicit success/failure split
+- the failure value has a meaningful type
+- you want right-biased functional composition
+
+Use `Result` or `Result<T>` when:
+
+- you want structured message collections
+- you need application or HTTP-oriented error categories
+- warnings, codes, and sources matter as part of the outcome
+
+## Summary
+
+`Either<TLeft, TRight>` helps make recoverable failure explicit.
+
+Its main practical advantages are:
+
+- clear success/failure contracts
+- right-biased composition with `Map` and `Bind`
+- predictable short-circuiting on failure
+- explicit handling through `Match`

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -195,6 +195,25 @@ var message = order.Match(
 );
 ```
 
+## Example: controller layer
+
+When a controller only needs to branch on presence or absence, `Maybe<T>.Match` keeps that decision explicit:
+
+```csharp
+[HttpGet("{id:guid}")]
+public async Task<IActionResult> GetById(Guid id)
+{
+    var customer = await _service.FindCustomerAsync(id);
+
+    return customer.Match<IActionResult>(
+        onFull: value => Ok(value),
+        onEmpty: () => NotFound()
+    );
+}
+```
+
+If the endpoint also needs richer validation or business error details, prefer returning `Result<T>` from the service and translating that at the HTTP boundary.
+
 ## When to use `Maybe<T>` vs `Result<T>`
 
 Use `Maybe<T>` when:

--- a/docs/maybe.md
+++ b/docs/maybe.md
@@ -1,0 +1,221 @@
+# Maybe
+
+## What problem `Maybe<T>` solves
+
+In everyday application code, we often need to represent "a value may exist, or it may not".
+
+The most common ways to model that are:
+
+- `null`
+- sentinel values such as `0`, `Guid.Empty`, or `""`
+- exceptions for normal absence
+
+Those approaches tend to hide intent. They force readers to remember conventions instead of letting the type system express what is actually happening.
+
+`Maybe<T>` makes absence explicit.
+
+Instead of saying "this method returns a `T`, but sometimes that `T` is not really there", the API says:
+
+- you will receive either a full value
+- or an empty value container
+
+That small shift has practical advantages:
+
+- clearer method contracts
+- less accidental null handling
+- easier branching at the call site
+- better readability in services and repositories
+
+## The theory, in small doses
+
+`Maybe<T>` is an "optional value" abstraction.
+
+In functional programming terms, it helps you model computations where a value may be missing, without falling back to unchecked null semantics.
+
+The important practical idea is simple:
+
+- `T` means "a value is expected"
+- `Maybe<T>` means "a value may or may not be present"
+
+You do not need deep category theory to benefit from it. The win is mostly about making intent explicit and removing ambiguity from APIs.
+
+## Main API
+
+`Maybe<T>` currently provides:
+
+- `Create()`
+- `Create(value)`
+- `Empty()`
+- `Full(value)`
+- `IsEmpty`
+- `IsFull`
+- `Value`
+- implicit conversion from `T` to `Maybe<T>`
+- `Match`
+
+## Creating values
+
+### Empty value
+
+```csharp
+var maybe = Maybe<int>.Empty();
+
+Console.WriteLine(maybe.IsEmpty); // true
+Console.WriteLine(maybe.IsFull);  // false
+```
+
+### Full value
+
+```csharp
+var maybe = Maybe<string>.Full("funcfy");
+
+Console.WriteLine(maybe.IsEmpty); // false
+Console.WriteLine(maybe.IsFull);  // true
+Console.WriteLine(maybe.Value);   // funcfy
+```
+
+### Implicit conversion
+
+```csharp
+Maybe<int> maybe = 42;
+```
+
+This is equivalent to:
+
+```csharp
+var maybe = Maybe<int>.Create(42);
+```
+
+## Branching with `Match`
+
+`Match` is one of the biggest practical advantages of using `Maybe<T>`.
+
+It lets you handle both branches in one place:
+
+```csharp
+Maybe<int> maybe = 42;
+
+var text = maybe.Match(
+    onFull: value => $"Found: {value}",
+    onEmpty: () => "No value"
+);
+```
+
+That keeps the handling explicit and local.
+
+You can also use the action overload:
+
+```csharp
+maybe.Match(
+    onFull: value => Console.WriteLine($"Processing {value}"),
+    onEmpty: () => Console.WriteLine("Nothing to process")
+);
+```
+
+## Advantages in practice
+
+### 1. Better repository/service contracts
+
+Without `Maybe<T>`:
+
+```csharp
+public Task<User?> FindByIdAsync(Guid id);
+```
+
+This works, but the caller must remember that `null` is a normal outcome.
+
+With `Maybe<T>`:
+
+```csharp
+public Task<Maybe<User>> FindByIdAsync(Guid id);
+```
+
+Now the contract itself tells the truth.
+
+Caller code becomes more intentional:
+
+```csharp
+var user = await repository.FindByIdAsync(id);
+
+var response = user.Match(
+    onFull: value => $"User found: {value.Name}",
+    onEmpty: () => "User not found"
+);
+```
+
+### 2. Fewer hidden conventions
+
+Sentinel values often age badly:
+
+```csharp
+// Does 0 mean "not found" or is 0 a valid value?
+int customerLevel = GetCustomerLevel();
+```
+
+With `Maybe<int>`, the contract is unambiguous:
+
+```csharp
+Maybe<int> customerLevel = GetCustomerLevel();
+```
+
+### 3. Cleaner branching than repeated `if` checks
+
+`Match` reduces scattered conditionals:
+
+```csharp
+var discount = maybeDiscount.Match(
+    onFull: value => value,
+    onEmpty: () => 0m
+);
+```
+
+This reads as a complete decision instead of a half-remembered null check.
+
+## Example: service layer
+
+```csharp
+public async Task<Maybe<Order>> FindOrderAsync(Guid id)
+{
+    var entity = await _dbContext.Orders.FindAsync(id);
+
+    return entity is null
+        ? Maybe<Order>.Empty()
+        : Maybe<Order>.Full(entity);
+}
+```
+
+Usage:
+
+```csharp
+var order = await service.FindOrderAsync(orderId);
+
+var message = order.Match(
+    onFull: value => $"Order total: {value.Total}",
+    onEmpty: () => "Order not found"
+);
+```
+
+## When to use `Maybe<T>` vs `Result<T>`
+
+Use `Maybe<T>` when:
+
+- the main question is whether a value exists
+- absence is normal and expected
+- you do not need structured failure details
+
+Use `Result<T>` when:
+
+- you need success/failure semantics
+- you want warnings or structured messages
+- you need application or HTTP-oriented error categories
+
+## Summary
+
+`Maybe<T>` is valuable because it turns implicit absence into explicit intent.
+
+That gives you:
+
+- clearer APIs
+- safer calling code
+- easier branching
+- less reliance on `null` or sentinel conventions

--- a/docs/result.md
+++ b/docs/result.md
@@ -233,6 +233,30 @@ var result = Result<string>.Create()
     .SetValue("cached-response");
 ```
 
+## Example: result extension helpers in a service
+
+The fluent extension helpers are useful when a service needs to accumulate business and validation messages while keeping a single return type:
+
+```csharp
+public Result ValidateProfile(UpdateProfileCommand command)
+{
+    var result = Result.Create();
+
+    if (string.IsNullOrWhiteSpace(command.DisplayName))
+        result.WithBadRequest("Display name is required", code: "DISPLAY_NAME_REQUIRED", source: nameof(command.DisplayName));
+
+    if (command.DisplayName?.Length > 100)
+        result.WithBusinessError("Display name is too long", code: "DISPLAY_NAME_TOO_LONG", source: nameof(command.DisplayName));
+
+    if (result.IsSuccessful)
+        result.WithInformation("Profile validation passed", code: "PROFILE_VALIDATED");
+
+    return result;
+}
+```
+
+That same pattern works with `Result<T>` when the operation also needs to return data.
+
 ## `Match` in practice
 
 `Match` helps keep the handling logic close to the result.

--- a/docs/result.md
+++ b/docs/result.md
@@ -1,0 +1,320 @@
+# Result
+
+## What problem `Result` solves
+
+Many operations need to tell you more than just "a value exists" or "a value is missing".
+
+They may need to communicate:
+
+- success
+- failure
+- warnings
+- validation problems
+- authorization problems
+- not-found conditions
+
+Returning only a raw value does not express that well.
+
+Throwing exceptions for every expected business outcome also tends to make application code noisy and harder to reason about.
+
+`Result` and `Result<T>` give you a structured way to model operation outcomes.
+
+## The theory, in practical terms
+
+A result type is useful when an operation has two dimensions:
+
+- whether it succeeded
+- what information should travel with that outcome
+
+In `funcfy`:
+
+- `Result` models outcome plus messages, without a return value
+- `Result<T>` models outcome plus messages, with optional data
+
+This is especially helpful in service-layer code, validation flows, and API-oriented applications, where failure is often expected and meaningful, not exceptional.
+
+## The building blocks
+
+### `Message`
+
+`Message` carries:
+
+- `Content`
+- `Type`
+- `Code`
+- `Source`
+
+### `MessageType`
+
+The library supports informational, warning, and error-oriented categories, including:
+
+- `Info`
+- `Warning`
+- `BusinessError`
+- `BadRequest`
+- `Unauthorized`
+- `Forbidden`
+- `NotFound`
+- `Conflict`
+- `ServerError`
+- `ServiceUnavailable`
+
+That makes result handling much richer than a simple `bool`.
+
+## `Result`
+
+Use non-generic `Result` when an operation does not need to return a payload.
+
+Main API:
+
+- `Create()`
+- `Success()`
+- `Failure(message)`
+- `Messages`
+- `Failed`
+- `IsSuccessful`
+- `Match`
+
+### Example
+
+```csharp
+var result = Result.Success()
+    .WithInformation("Customer updated");
+```
+
+Branching:
+
+```csharp
+var status = result.Match(
+    onSuccess: () => "ok",
+    onFailure: messages => $"failed: {messages[0].Content}"
+);
+```
+
+### Why this is useful
+
+This style makes application code easier to read than passing booleans and out parameters around.
+
+Instead of:
+
+```csharp
+bool ok = UpdateCustomer(customer, out var errorMessage);
+```
+
+you can express the full outcome:
+
+```csharp
+var result = UpdateCustomer(customer);
+```
+
+and inspect it in a meaningful way.
+
+## `Result<T>`
+
+Use `Result<T>` when you need outcome semantics and data.
+
+Main API:
+
+- `Create()`
+- `Create(value)`
+- `Success()`
+- `Success(value)`
+- `Failure(...)`
+- `Data` as `Maybe<T>`
+- `SetValue(value)`
+- `Match`
+
+An important design detail:
+
+`Result<T>.Success()` is valid even when `Data` is empty.
+
+That means:
+
+- the operation may succeed
+- but still not have a payload
+
+Because of that, the success branch of `Match` receives `Maybe<T>`, not raw `T`.
+
+### Example
+
+```csharp
+var result = Result<string>.Success("funcfy");
+
+var output = result.Match(
+    onSuccess: maybe => maybe.Match(
+        onFull: value => value.ToUpperInvariant(),
+        onEmpty: () => "SUCCESS_WITHOUT_VALUE"
+    ),
+    onFailure: messages => messages[0].Content
+);
+```
+
+## Advantages in practice
+
+### 1. Explicit business outcomes
+
+A result can express things that a boolean cannot:
+
+```csharp
+var result = Result.Failure(
+    Message.Create("Customer not found", MessageType.NotFound, code: "CUST_404")
+);
+```
+
+Now you have:
+
+- the outcome
+- the category
+- the message text
+- an optional code
+
+all in one place.
+
+### 2. Rich validation flows
+
+Results make validation accumulation more natural:
+
+```csharp
+var result = Result.Create();
+
+if (string.IsNullOrWhiteSpace(command.Name))
+    result.WithBadRequest("Name is required", code: "NAME_REQUIRED");
+
+if (command.Age < 18)
+    result.WithBusinessError("Minimum age is 18", code: "AGE_INVALID");
+```
+
+That is much easier to extend than throwing multiple exceptions or short-circuiting too early.
+
+### 3. Better service-layer APIs
+
+Instead of returning a nullable payload and relying on conventions:
+
+```csharp
+public async Task<Customer?> GetCustomerAsync(Guid id);
+```
+
+you can return:
+
+```csharp
+public async Task<Result<Customer>> GetCustomerAsync(Guid id);
+```
+
+and then represent:
+
+- success with data
+- success without data
+- not found
+- unauthorized
+- conflict
+
+without changing the method shape.
+
+## Fluent message helpers
+
+Both `Result` and `Result<T>` support fluent helpers like:
+
+- `WithInformation`
+- `WithWarning`
+- `WithBusinessError`
+- `WithBadRequest`
+- `WithUnauthorized`
+- `WithForbidden`
+- `WithNotFound`
+- `WithConflict`
+- `WithServerError`
+- `WithServiceUnavailable`
+
+Example:
+
+```csharp
+var result = Result<string>.Create()
+    .WithWarning("Using cached value")
+    .SetValue("cached-response");
+```
+
+## `Match` in practice
+
+`Match` helps keep the handling logic close to the result.
+
+### Functional style
+
+```csharp
+var response = result.Match(
+    onSuccess: maybe => maybe.Match(
+        onFull: value => new { ok = true, value },
+        onEmpty: () => new { ok = true, value = (string?)null }
+    ),
+    onFailure: messages => new { ok = false, error = messages[0].Content }
+);
+```
+
+### Action style
+
+```csharp
+result.Match(
+    onSuccess: maybe =>
+    {
+        // continue pipeline
+    },
+    onFailure: messages =>
+    {
+        _logger.LogWarning("Operation failed: {Message}", messages[0].Content);
+    }
+);
+```
+
+## Example: application service
+
+```csharp
+public async Task<Result<CustomerDto>> GetCustomerAsync(Guid id)
+{
+    var customer = await _repository.FindByIdAsync(id);
+
+    return customer.Match(
+        onFull: entity => Result<CustomerDto>.Success(new CustomerDto(entity.Id, entity.Name)),
+        onEmpty: () => Result<CustomerDto>.Failure(
+            Message.Create("Customer not found", MessageType.NotFound, code: "CUSTOMER_NOT_FOUND")
+        )
+    );
+}
+```
+
+At the call site:
+
+```csharp
+var result = await service.GetCustomerAsync(id);
+
+var text = result.Match(
+    onSuccess: maybe => maybe.Match(
+        onFull: dto => dto.Name,
+        onEmpty: () => "No payload"
+    ),
+    onFailure: messages => messages[0].Content
+);
+```
+
+## When to use `Result` vs `Maybe`
+
+Use `Maybe<T>` when:
+
+- you only care whether a value exists
+- absence is normal
+- you do not need structured failure details
+
+Use `Result` or `Result<T>` when:
+
+- you need explicit success/failure modeling
+- you want messages, categories, codes, or sources
+- you want easier integration with application and HTTP workflows
+
+## Summary
+
+`Result` helps move application code away from hidden conventions.
+
+Its main practical advantages are:
+
+- richer method contracts
+- structured business and HTTP-like outcomes
+- easier branching with `Match`
+- better composition between services, validation, and controller code

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,8 +4,8 @@
 
 The intended scope of `funcfy` is centered on these feature areas:
 
-- currying and partial application
 - `Either`, `Maybe`, and `Result` types
+- currying and partial application
 - `Functor`, `Applicative`, and `Monad` interfaces
 - lens utilities, compose, and pipe helpers
 
@@ -16,23 +16,24 @@ The intended scope of `funcfy` is centered on these feature areas:
 - success/failure `Match` support for `Result` and `Result<T>`
 - typed message helpers for common application and HTTP-style error cases
 - ASP.NET Core `IActionResult` conversion for non-generic results
+- .NET 8-aligned ASP.NET Core runtime references and integration-style action result tests
+- focused docs and service/controller examples for `Maybe<T>`, `Result`, and ASP.NET Core usage
+- root changelog and release-notes visibility from the README and docs index
 - CI/release workflow separation for tagging and prerelease publishing
 
 ## Near Term
 
-- improve package/runtime consistency in test execution and ASP.NET Core integration tests
-- add focused docs for `Maybe<T>`, `Result`, and result extension helpers
-- add examples for common service-layer and controller-layer usage
-- improve release notes and changelog visibility
+- add `Either` as a first-class monad in the library surface
+- expand result-to-HTTP integration for generic `Result<T>`
+- document guidance for message codes, sources, and error handling conventions
 
 ## Next
 
-- add `Either` as a first-class monad in the library surface
+- evaluate multi-targeting for `net8.0`, `net9.0`, and `net10.0`
+- define package validation coverage for each supported target framework
 - introduce currying and partial application helpers
 - define foundational `Functor`, `Applicative`, and `Monad` interfaces
 - add compose and pipe helpers for function composition
-- expand result-to-HTTP integration for generic results
-- document guidance for message codes, sources, and error handling conventions
 - add richer composition examples for `Maybe<T>` and `Result<T>`
 
 ## Later

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,42 @@
+# Roadmap
+
+## Library Scope
+
+The intended scope of `funcfy` is centered on these feature areas:
+
+- currying and partial application
+- `Either`, `Maybe`, and `Result` types
+- `Functor`, `Applicative`, and `Monad` interfaces
+- lens utilities, compose, and pipe helpers
+
+## Current
+
+- `Maybe<T>` with creation helpers, implicit conversion, and `Match`
+- `Result` and `Result<T>` with structured messages
+- success/failure `Match` support for `Result` and `Result<T>`
+- typed message helpers for common application and HTTP-style error cases
+- ASP.NET Core `IActionResult` conversion for non-generic results
+- CI/release workflow separation for tagging and prerelease publishing
+
+## Near Term
+
+- improve package/runtime consistency in test execution and ASP.NET Core integration tests
+- add focused docs for `Maybe<T>`, `Result`, and result extension helpers
+- add examples for common service-layer and controller-layer usage
+- improve release notes and changelog visibility
+
+## Next
+
+- add `Either` as a first-class monad in the library surface
+- introduce currying and partial application helpers
+- define foundational `Functor`, `Applicative`, and `Monad` interfaces
+- add compose and pipe helpers for function composition
+- expand result-to-HTTP integration for generic results
+- document guidance for message codes, sources, and error handling conventions
+- add richer composition examples for `Maybe<T>` and `Result<T>`
+
+## Later
+
+- evaluate lens utilities once the core monad and composition APIs are stable
+- evaluate whether to add additional monads or functional helpers only after the current primitives are well documented and stable
+- consider a dedicated documentation site if the `docs/` folder grows beyond repository-scale guides

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,7 @@ The intended scope of `funcfy` is centered on these feature areas:
 ## Current
 
 - `Maybe<T>` with creation helpers, implicit conversion, and `Match`
+- `Either<TLeft, TRight>` with explicit left/right creation, right-biased composition, and conversion helpers
 - `Result` and `Result<T>` with structured messages
 - success/failure `Match` support for `Result` and `Result<T>`
 - typed message helpers for common application and HTTP-style error cases
@@ -23,7 +24,6 @@ The intended scope of `funcfy` is centered on these feature areas:
 
 ## Near Term
 
-- add `Either` as a first-class monad in the library surface
 - expand result-to-HTTP integration for generic `Result<T>`
 - document guidance for message codes, sources, and error handling conventions
 

--- a/src/Funcfy/Funcfy.csproj
+++ b/src/Funcfy/Funcfy.csproj
@@ -28,9 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/src/Funcfy/Monads/Either.cs
+++ b/src/Funcfy/Monads/Either.cs
@@ -1,0 +1,253 @@
+using Funcfy.Monads.Extensions;
+using System.Runtime.Serialization;
+
+namespace Funcfy.Monads;
+
+/// <summary>
+/// Provides factory methods for creating <see cref="Either{TLeft, TRight}"/> instances.
+/// </summary>
+public static class Either
+{
+    /// <summary>
+    /// Creates a new <see cref="Either{TLeft, TRight}"/> in the left state.
+    /// </summary>
+    /// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+    /// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+    /// <param name="value">The value to store in the left branch.</param>
+    /// <returns>A new left <see cref="Either{TLeft, TRight}"/>.</returns>
+    public static Either<TLeft, TRight> Left<TLeft, TRight>(TLeft value) => Either<TLeft, TRight>.CreateLeft(value);
+
+    /// <summary>
+    /// Creates a new <see cref="Either{TLeft, TRight}"/> in the right state.
+    /// </summary>
+    /// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+    /// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+    /// <param name="value">The value to store in the right branch.</param>
+    /// <returns>A new right <see cref="Either{TLeft, TRight}"/>.</returns>
+    public static Either<TLeft, TRight> Right<TLeft, TRight>(TRight value) => Either<TLeft, TRight>.CreateRight(value);
+}
+
+/// <summary>
+/// Represents a recoverable computation that can return either a left value or a right value.
+/// By convention, left represents failure and right represents success.
+/// </summary>
+/// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+/// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+[DataContract]
+public sealed record Either<TLeft, TRight>
+{
+    /// <summary>
+    /// Indicates whether the current instance is in the left state.
+    /// </summary>
+    [DataMember]
+    public bool IsLeft => Branch == EitherBranch.Left;
+
+    /// <summary>
+    /// Indicates whether the current instance is in the right state.
+    /// </summary>
+    [DataMember]
+    public bool IsRight => Branch == EitherBranch.Right;
+
+    [DataMember]
+    private EitherBranch Branch { get; init; }
+
+    [DataMember]
+    private TLeft? LeftValue { get; init; }
+
+    [DataMember]
+    private TRight? RightValue { get; init; }
+
+    private Either() { }
+
+    private Either(EitherBranch branch, TLeft? leftValue = default, TRight? rightValue = default)
+    {
+        Branch = branch;
+        LeftValue = leftValue;
+        RightValue = rightValue;
+    }
+
+    internal static Either<TLeft, TRight> CreateLeft(TLeft value) => new(EitherBranch.Left, leftValue: value);
+
+    internal static Either<TLeft, TRight> CreateRight(TRight value) => new(EitherBranch.Right, rightValue: value);
+
+    /// <summary>
+    /// Pattern matches over the current instance and returns the value produced by the matching branch.
+    /// </summary>
+    /// <typeparam name="TResult">The type returned by the selected branch.</typeparam>
+    /// <param name="onLeft">Function executed when the instance is left.</param>
+    /// <param name="onRight">Function executed when the instance is right.</param>
+    /// <returns>The result produced by the selected branch.</returns>
+    public TResult Match<TResult>(Func<TLeft, TResult> onLeft, Func<TRight, TResult> onRight)
+    {
+        ArgumentNullException.ThrowIfNull(onLeft);
+        ArgumentNullException.ThrowIfNull(onRight);
+
+        return Branch switch
+        {
+            EitherBranch.Left => onLeft(LeftValue!),
+            EitherBranch.Right => onRight(RightValue!),
+            _ => throw new InvalidOperationException("The Either instance is in an invalid state.")
+        };
+    }
+
+    /// <summary>
+    /// Pattern matches over the current instance and executes the matching action.
+    /// </summary>
+    /// <param name="onLeft">Action executed when the instance is left.</param>
+    /// <param name="onRight">Action executed when the instance is right.</param>
+    public void Match(Action<TLeft> onLeft, Action<TRight> onRight)
+    {
+        ArgumentNullException.ThrowIfNull(onLeft);
+        ArgumentNullException.ThrowIfNull(onRight);
+
+        Match(onLeft.WrapAsFunc(), onRight.WrapAsFunc());
+    }
+
+    /// <summary>
+    /// Transforms the right value while preserving the left branch.
+    /// </summary>
+    /// <typeparam name="TResult">The type produced by the mapping function.</typeparam>
+    /// <param name="mapper">Function used to transform the right value.</param>
+    /// <returns>A new <see cref="Either{TLeft, TResult}"/> containing the mapped right value, or the original left value.</returns>
+    public Either<TLeft, TResult> Map<TResult>(Func<TRight, TResult> mapper)
+    {
+        ArgumentNullException.ThrowIfNull(mapper);
+
+        return Match(
+            onLeft: left => Either.Left<TLeft, TResult>(left),
+            onRight: right => Either.Right<TLeft, TResult>(mapper(right))
+        );
+    }
+
+    /// <summary>
+    /// Transforms the left value while preserving the right branch.
+    /// </summary>
+    /// <typeparam name="TResult">The type produced by the mapping function.</typeparam>
+    /// <param name="mapper">Function used to transform the left value.</param>
+    /// <returns>A new <see cref="Either{TResult, TRight}"/> containing the mapped left value, or the original right value.</returns>
+    public Either<TResult, TRight> MapLeft<TResult>(Func<TLeft, TResult> mapper)
+    {
+        ArgumentNullException.ThrowIfNull(mapper);
+
+        return Match(
+            onLeft: left => Either.Left<TResult, TRight>(mapper(left)),
+            onRight: right => Either.Right<TResult, TRight>(right)
+        );
+    }
+
+    /// <summary>
+    /// Chains computations that return <see cref="Either{TLeft, TResult}"/>, short-circuiting when the current instance is left.
+    /// </summary>
+    /// <typeparam name="TResult">The type carried by the bound right value.</typeparam>
+    /// <param name="binder">Function used to continue the computation when the instance is right.</param>
+    /// <returns>The result produced by the binder, or the original left value.</returns>
+    public Either<TLeft, TResult> Bind<TResult>(Func<TRight, Either<TLeft, TResult>> binder)
+    {
+        ArgumentNullException.ThrowIfNull(binder);
+
+        return Match(
+            onLeft: left => Either.Left<TLeft, TResult>(left),
+            onRight: right => binder(right) ?? throw new InvalidOperationException("The binder returned null.")
+        );
+    }
+
+    /// <summary>
+    /// Returns the right value when present, otherwise returns the provided fallback value.
+    /// </summary>
+    /// <param name="fallback">Fallback value used when the instance is left.</param>
+    /// <returns>The right value, or <paramref name="fallback"/> when the instance is left.</returns>
+    public TRight GetOrElse(TRight fallback)
+        => Match(
+            onLeft: _ => fallback,
+            onRight: right => right
+        );
+
+    /// <summary>
+    /// Returns the right value when present, otherwise computes a fallback value from the left branch.
+    /// </summary>
+    /// <param name="onLeft">Function used to produce a fallback value from the left branch.</param>
+    /// <returns>The right value, or the value produced by <paramref name="onLeft"/> when the instance is left.</returns>
+    public TRight GetOrElse(Func<TLeft, TRight> onLeft)
+    {
+        ArgumentNullException.ThrowIfNull(onLeft);
+
+        return Match(
+            onLeft: onLeft,
+            onRight: right => right
+        );
+    }
+
+    /// <summary>
+    /// Returns the current instance when it is right; otherwise computes an alternative instance from the left value.
+    /// </summary>
+    /// <param name="onLeft">Function used to compute the fallback instance.</param>
+    /// <returns>The current instance when it is right, otherwise the fallback instance.</returns>
+    public Either<TLeft, TRight> OrElse(Func<TLeft, Either<TLeft, TRight>> onLeft)
+    {
+        ArgumentNullException.ThrowIfNull(onLeft);
+
+        return Match(
+            onLeft: left => onLeft(left) ?? throw new InvalidOperationException("The fallback returned null."),
+            onRight: _ => this
+        );
+    }
+
+    /// <summary>
+    /// Returns the current instance when it is right; otherwise computes an alternative instance.
+    /// </summary>
+    /// <param name="fallback">Function used to compute the fallback instance.</param>
+    /// <returns>The current instance when it is right, otherwise the fallback instance.</returns>
+    public Either<TLeft, TRight> OrElse(Func<Either<TLeft, TRight>> fallback)
+    {
+        ArgumentNullException.ThrowIfNull(fallback);
+
+        return Match(
+            onLeft: _ => fallback() ?? throw new InvalidOperationException("The fallback returned null."),
+            onRight: _ => this
+        );
+    }
+
+    /// <summary>
+    /// Executes a side effect when the instance is right and returns the original instance.
+    /// </summary>
+    /// <param name="onRight">Action executed when the instance is right.</param>
+    /// <returns>The original <see cref="Either{TLeft, TRight}"/> instance.</returns>
+    public Either<TLeft, TRight> Tap(Action<TRight> onRight)
+    {
+        ArgumentNullException.ThrowIfNull(onRight);
+
+        Match(
+            onLeft: _ => { },
+            onRight: onRight
+        );
+
+        return this;
+    }
+
+    /// <summary>
+    /// Executes a side effect when the instance is left and returns the original instance.
+    /// </summary>
+    /// <param name="onLeft">Action executed when the instance is left.</param>
+    /// <returns>The original <see cref="Either{TLeft, TRight}"/> instance.</returns>
+    public Either<TLeft, TRight> TapLeft(Action<TLeft> onLeft)
+    {
+        ArgumentNullException.ThrowIfNull(onLeft);
+
+        Match(
+            onLeft: onLeft,
+            onRight: _ => { }
+        );
+
+        return this;
+    }
+
+    [DataContract]
+    private enum EitherBranch : byte
+    {
+        [EnumMember]
+        Left = 0,
+
+        [EnumMember]
+        Right = 1
+    }
+}

--- a/src/Funcfy/Monads/Extensions/EitherExtensions.cs
+++ b/src/Funcfy/Monads/Extensions/EitherExtensions.cs
@@ -1,0 +1,67 @@
+namespace Funcfy.Monads.Extensions;
+
+/// <summary>
+/// Provides conversion helpers for <see cref="Either{TLeft, TRight}"/>.
+/// </summary>
+public static class EitherExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="Maybe{TRight}"/> to an <see cref="Either{TLeft, TRight}"/>.
+    /// </summary>
+    /// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+    /// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+    /// <param name="maybe">The optional value to convert.</param>
+    /// <param name="onEmpty">Function used to produce the left value when the maybe is empty.</param>
+    /// <returns>A right either when the maybe is full; otherwise a left either.</returns>
+    public static Either<TLeft, TRight> ToEither<TLeft, TRight>(this Maybe<TRight> maybe, Func<TLeft> onEmpty)
+    {
+        ArgumentNullException.ThrowIfNull(maybe);
+        ArgumentNullException.ThrowIfNull(onEmpty);
+
+        return maybe.Match(
+            onFull: value => Either.Right<TLeft, TRight>(value),
+            onEmpty: () => Either.Left<TLeft, TRight>(onEmpty())
+        );
+    }
+
+    /// <summary>
+    /// Converts an <see cref="Either{TLeft, TRight}"/> to a <see cref="Maybe{TRight}"/> by discarding the left value.
+    /// </summary>
+    /// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+    /// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+    /// <param name="either">The either value to convert.</param>
+    /// <returns>A full maybe when the either is right; otherwise an empty maybe.</returns>
+    public static Maybe<TRight> ToMaybe<TLeft, TRight>(this Either<TLeft, TRight> either)
+    {
+        ArgumentNullException.ThrowIfNull(either);
+
+        return either.Match(
+            onLeft: _ => Maybe<TRight>.Empty(),
+            onRight: Maybe<TRight>.Full
+        );
+    }
+
+    /// <summary>
+    /// Converts an <see cref="Either{TLeft, TRight}"/> to a <see cref="Result{TRight}"/>.
+    /// </summary>
+    /// <typeparam name="TLeft">The type carried by the left branch.</typeparam>
+    /// <typeparam name="TRight">The type carried by the right branch.</typeparam>
+    /// <param name="either">The either value to convert.</param>
+    /// <param name="mapLeft">Function used to map the left value to a <see cref="Message"/>.</param>
+    /// <returns>A successful result for a right either, or a failure result for a left either.</returns>
+    public static Result<TRight> ToResult<TLeft, TRight>(this Either<TLeft, TRight> either, Func<TLeft, Message> mapLeft)
+    {
+        ArgumentNullException.ThrowIfNull(either);
+        ArgumentNullException.ThrowIfNull(mapLeft);
+
+        return either.Match(
+            onLeft: left =>
+            {
+                var message = mapLeft(left);
+                ArgumentNullException.ThrowIfNull(message);
+                return Result<TRight>.Failure(message);
+            },
+            onRight: Result<TRight>.Success
+        );
+    }
+}

--- a/tests/Funcfy.Tests/Funcfy.Tests.csproj
+++ b/tests/Funcfy.Tests/Funcfy.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\src\Funcfy\Funcfy.csproj" />
   </ItemGroup>
 

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/BindUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/BindUnitTests.cs
@@ -1,0 +1,54 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class BindUnitTests
+{
+    [Fact]
+    public void Bind_WhenRight_ShouldChainComputations()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+
+        // Act
+        var bound = either.Bind(value => Either.Right<string, int>(value + 5));
+
+        // Assert
+        bound.IsRight.ShouldBeTrue();
+        bound.Match(left => left.Length, right => right).ShouldBe(15);
+    }
+
+    [Fact]
+    public void Bind_WhenRightAndBinderReturnsLeft_ShouldReturnLeft()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+
+        // Act
+        var bound = either.Bind(_ => Either.Left<string, int>("failure"));
+
+        // Assert
+        bound.IsLeft.ShouldBeTrue();
+        bound.Match(left => left, right => right.ToString()).ShouldBe("failure");
+    }
+
+    [Fact]
+    public void Bind_WhenLeft_ShouldShortCircuit()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("invalid");
+        var binderCallCount = 0;
+
+        // Act
+        var bound = either.Bind(value =>
+        {
+            binderCallCount++;
+            return Either.Right<string, int>(value * 2);
+        });
+
+        // Assert
+        binderCallCount.ShouldBe(0);
+        bound.IsLeft.ShouldBeTrue();
+        bound.Match(left => left, right => right.ToString()).ShouldBe("invalid");
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/BindUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/BindUnitTests.cs
@@ -51,4 +51,14 @@ public class BindUnitTests
         bound.IsLeft.ShouldBeTrue();
         bound.Match(left => left, right => right.ToString()).ShouldBe("invalid");
     }
+
+    [Fact]
+    public void Bind_WhenBinderReturnsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => either.Bind<int>(_ => null!));
+    }
 }

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/ConversionUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/ConversionUnitTests.cs
@@ -21,6 +21,26 @@ public class ConversionUnitTests
     }
 
     [Fact]
+    public void ToEither_WhenMaybeIsFull_ShouldNotInvokeOnEmptyFactory()
+    {
+        // Arrange
+        Maybe<int> maybe = 42;
+        var factoryCallCount = 0;
+
+        // Act
+        var either = maybe.ToEither(() =>
+        {
+            factoryCallCount++;
+            return "missing";
+        });
+
+        // Assert
+        factoryCallCount.ShouldBe(0);
+        either.IsRight.ShouldBeTrue();
+        either.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+
+    [Fact]
     public void ToEither_WhenMaybeIsEmpty_ShouldReturnLeft()
     {
         // Arrange
@@ -93,5 +113,15 @@ public class ConversionUnitTests
         result.Messages[0].Content.ShouldBe("missing");
         result.Messages[0].Type.ShouldBe(MessageType.NotFound);
         result.Messages[0].Code.ShouldBe("NF001");
+    }
+
+    [Fact]
+    public void ToResult_WhenMapLeftReturnsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.ToResult(_ => null!));
     }
 }

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/ConversionUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/ConversionUnitTests.cs
@@ -1,0 +1,97 @@
+using Funcfy.Monads;
+using Funcfy.Monads.Enums;
+using Funcfy.Monads.Extensions;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class ConversionUnitTests
+{
+    [Fact]
+    public void ToEither_WhenMaybeIsFull_ShouldReturnRight()
+    {
+        // Arrange
+        Maybe<int> maybe = 42;
+
+        // Act
+        var either = maybe.ToEither(() => "missing");
+
+        // Assert
+        either.IsRight.ShouldBeTrue();
+        either.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+
+    [Fact]
+    public void ToEither_WhenMaybeIsEmpty_ShouldReturnLeft()
+    {
+        // Arrange
+        var maybe = Maybe<int>.Empty();
+
+        // Act
+        var either = maybe.ToEither(() => "missing");
+
+        // Assert
+        either.IsLeft.ShouldBeTrue();
+        either.Match(left => left, right => right.ToString()).ShouldBe("missing");
+    }
+
+    [Fact]
+    public void ToMaybe_WhenEitherIsRight_ShouldReturnFullMaybe()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act
+        var maybe = either.ToMaybe();
+
+        // Assert
+        maybe.IsFull.ShouldBeTrue();
+        maybe.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void ToMaybe_WhenEitherIsLeft_ShouldReturnEmptyMaybe()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var maybe = either.ToMaybe();
+
+        // Assert
+        maybe.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ToResult_WhenEitherIsRight_ShouldReturnSuccessfulResult()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act
+        var result = either.ToResult(left => Message.Create(left, MessageType.BusinessError));
+
+        // Assert
+        result.IsSuccessful.ShouldBeTrue();
+        result.Data.IsFull.ShouldBeTrue();
+        result.Data.Value.ShouldBe(42);
+        result.Messages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ToResult_WhenEitherIsLeft_ShouldReturnFailureResult()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var result = either.ToResult(left => Message.Create(left, MessageType.NotFound, code: "NF001"));
+
+        // Assert
+        result.Failed.ShouldBeTrue();
+        result.Data.IsEmpty.ShouldBeTrue();
+        result.Messages.Count.ShouldBe(1);
+        result.Messages[0].Content.ShouldBe("missing");
+        result.Messages[0].Type.ShouldBe(MessageType.NotFound);
+        result.Messages[0].Code.ShouldBe("NF001");
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/CreateUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/CreateUnitTests.cs
@@ -1,0 +1,36 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class CreateUnitTests
+{
+    [Fact]
+    public void Left_WhenCalled_ShouldCreateLeftInstance()
+    {
+        // Arrange
+        const string error = "invalid";
+
+        // Act
+        var either = Either.Left<string, int>(error);
+
+        // Assert
+        either.IsLeft.ShouldBeTrue();
+        either.IsRight.ShouldBeFalse();
+        either.Match(left => left, right => right.ToString()).ShouldBe(error);
+    }
+
+    [Fact]
+    public void Right_WhenCalled_ShouldCreateRightInstance()
+    {
+        // Arrange
+        const int value = 42;
+
+        // Act
+        var either = Either.Right<string, int>(value);
+
+        // Assert
+        either.IsRight.ShouldBeTrue();
+        either.IsLeft.ShouldBeFalse();
+        either.Match(left => left.Length, right => right).ShouldBe(value);
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/EqualityAndMonadLawsUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/EqualityAndMonadLawsUnitTests.cs
@@ -1,0 +1,112 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class EqualityAndMonadLawsUnitTests
+{
+    [Fact]
+    public void Equality_WhenSameBranchAndSamePayload_ShouldBeEqual()
+    {
+        // Arrange
+        var first = Either.Left<string, int>("failure");
+        var second = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void Equality_WhenDifferentBranchesWithDefaultPayload_ShouldNotBeEqual()
+    {
+        // Arrange
+        var left = Either.Left<int, int>(default);
+        var right = Either.Right<int, int>(default);
+
+        // Act & Assert
+        left.ShouldNotBe(right);
+    }
+
+    [Fact]
+    public void Equality_WhenDifferentBranchesWithEqualPayloads_ShouldNotBeEqual()
+    {
+        // Arrange
+        var left = Either.Left<int, int>(42);
+        var right = Either.Right<int, int>(42);
+
+        // Act & Assert
+        left.ShouldNotBe(right);
+    }
+
+    [Fact]
+    public void MonadLeftIdentity_ShouldHold()
+    {
+        // Arrange
+        const int value = 10;
+        Either<string, int> Step(int input) => Either.Right<string, int>(input + 5);
+
+        // Act
+        var leftSide = Either.Right<string, int>(value).Bind(Step);
+        var rightSide = Step(value);
+
+        // Assert
+        leftSide.ShouldBe(rightSide);
+    }
+
+    [Fact]
+    public void MonadRightIdentity_ShouldHoldForRight()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+
+        // Act
+        var result = either.Bind(value => Either.Right<string, int>(value));
+
+        // Assert
+        result.ShouldBe(either);
+    }
+
+    [Fact]
+    public void MonadRightIdentity_ShouldHoldForLeft()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act
+        var result = either.Bind(value => Either.Right<string, int>(value));
+
+        // Assert
+        result.ShouldBe(either);
+    }
+
+    [Fact]
+    public void MonadAssociativity_ShouldHoldForRight()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+        Either<string, int> StepOne(int input) => Either.Right<string, int>(input + 5);
+        Either<string, int> StepTwo(int input) => Either.Right<string, int>(input * 2);
+
+        // Act
+        var leftSide = either.Bind(StepOne).Bind(StepTwo);
+        var rightSide = either.Bind(value => StepOne(value).Bind(StepTwo));
+
+        // Assert
+        leftSide.ShouldBe(rightSide);
+    }
+
+    [Fact]
+    public void MonadAssociativity_ShouldHoldForLeft()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+        Either<string, int> StepOne(int input) => Either.Right<string, int>(input + 5);
+        Either<string, int> StepTwo(int input) => Either.Right<string, int>(input * 2);
+
+        // Act
+        var leftSide = either.Bind(StepOne).Bind(StepTwo);
+        var rightSide = either.Bind(value => StepOne(value).Bind(StepTwo));
+
+        // Assert
+        leftSide.ShouldBe(rightSide);
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/GuardUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/GuardUnitTests.cs
@@ -1,0 +1,147 @@
+using Funcfy.Monads;
+using Funcfy.Monads.Extensions;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class GuardUnitTests
+{
+    [Fact]
+    public void Match_WhenLeftFuncIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Match<string>(null!, right => right.ToString()));
+    }
+
+    [Fact]
+    public void Match_WhenRightFuncIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Match(left => left, null!));
+    }
+
+    [Fact]
+    public void Match_ActionOverload_WhenLeftActionIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Match(null!, _ => { }));
+    }
+
+    [Fact]
+    public void Match_ActionOverload_WhenRightActionIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Match(_ => { }, null!));
+    }
+
+    [Fact]
+    public void Map_WhenMapperIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Map<string>(null!));
+    }
+
+    [Fact]
+    public void MapLeft_WhenMapperIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.MapLeft<int>(null!));
+    }
+
+    [Fact]
+    public void Bind_WhenBinderIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Bind<int>(null!));
+    }
+
+    [Fact]
+    public void GetOrElse_WhenDelegateIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.GetOrElse(null!));
+    }
+
+    [Fact]
+    public void OrElse_WhenLeftDependentFallbackIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.OrElse((Func<string, Either<string, int>>)null!));
+    }
+
+    [Fact]
+    public void OrElse_WhenParameterlessFallbackIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.OrElse((Func<Either<string, int>>)null!));
+    }
+
+    [Fact]
+    public void Tap_WhenActionIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.Tap(null!));
+    }
+
+    [Fact]
+    public void TapLeft_WhenActionIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.TapLeft(null!));
+    }
+
+    [Fact]
+    public void ToEither_WhenOnEmptyIsNull_ShouldThrow()
+    {
+        // Arrange
+        var maybe = Maybe<int>.Empty();
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => maybe.ToEither<string, int>(null!));
+    }
+
+    [Fact]
+    public void ToResult_WhenMapLeftIsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => either.ToResult(null!));
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/InternalCoverageUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/InternalCoverageUnitTests.cs
@@ -1,0 +1,47 @@
+using Funcfy.Monads;
+using System.Reflection;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class InternalCoverageUnitTests
+{
+    [Fact]
+    public void WithExpression_ShouldCreateEqualButDistinctCopy()
+    {
+        // Arrange
+        var original = Either.Right<string, int>(42);
+
+        // Act
+        var copy = original with { };
+
+        // Assert
+        copy.ShouldBe(original);
+        ReferenceEquals(copy, original).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Match_WhenEitherIsInInvalidState_ShouldThrow()
+    {
+        // Arrange
+        var either = CreateInvalidEither<string, int>();
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => either.Match(left => left, right => right.ToString()));
+    }
+
+    private static Either<TLeft, TRight> CreateInvalidEither<TLeft, TRight>()
+    {
+        var type = typeof(Either<TLeft, TRight>);
+
+        var either = (Either<TLeft, TRight>)Activator.CreateInstance(type, nonPublic: true)!;
+
+        var branchField = type.GetField("<Branch>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+        branchField.ShouldNotBeNull();
+
+        var branchType = branchField!.FieldType;
+        var invalidBranch = Enum.ToObject(branchType, 2);
+        branchField.SetValue(either, invalidBranch);
+
+        return either;
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/MapUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/MapUnitTests.cs
@@ -1,0 +1,62 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class MapUnitTests
+{
+    [Fact]
+    public void Map_WhenRight_ShouldTransformRightValue()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(21);
+
+        // Act
+        var mapped = either.Map(value => value * 2);
+
+        // Assert
+        mapped.IsRight.ShouldBeTrue();
+        mapped.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+
+    [Fact]
+    public void Map_WhenLeft_ShouldPreserveLeftValue()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("invalid");
+
+        // Act
+        var mapped = either.Map(value => value * 2);
+
+        // Assert
+        mapped.IsLeft.ShouldBeTrue();
+        mapped.Match(left => left, right => right.ToString()).ShouldBe("invalid");
+    }
+
+    [Fact]
+    public void MapLeft_WhenLeft_ShouldTransformLeftValue()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("invalid");
+
+        // Act
+        var mapped = either.MapLeft(left => left.ToUpperInvariant());
+
+        // Assert
+        mapped.IsLeft.ShouldBeTrue();
+        mapped.Match(left => left, right => right.ToString()).ShouldBe("INVALID");
+    }
+
+    [Fact]
+    public void MapLeft_WhenRight_ShouldPreserveRightValue()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act
+        var mapped = either.MapLeft(left => left.Length);
+
+        // Assert
+        mapped.IsRight.ShouldBeTrue();
+        mapped.Match(left => left, right => right).ShouldBe(42);
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/MatchUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/MatchUnitTests.cs
@@ -1,0 +1,72 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class MatchUnitTests
+{
+    [Fact]
+    public void Match_WhenLeft_ShouldReturnLeftBranchResult()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var result = either.Match(
+            onLeft: left => left.ToUpperInvariant(),
+            onRight: right => right.ToString()
+        );
+
+        // Assert
+        result.ShouldBe("MISSING");
+    }
+
+    [Fact]
+    public void Match_WhenRight_ShouldReturnRightBranchResult()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(21);
+
+        // Act
+        var result = either.Match(
+            onLeft: left => left.Length,
+            onRight: right => right * 2
+        );
+
+        // Assert
+        result.ShouldBe(42);
+    }
+
+    [Fact]
+    public void Match_ActionOverload_WhenLeft_ShouldExecuteLeftAction()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+        var wasExecuted = false;
+
+        // Act
+        either.Match(
+            onLeft: _ => wasExecuted = true,
+            onRight: _ => { }
+        );
+
+        // Assert
+        wasExecuted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Match_ActionOverload_WhenRight_ShouldExecuteRightAction()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(10);
+        var wasExecuted = false;
+
+        // Act
+        either.Match(
+            onLeft: _ => { },
+            onRight: _ => wasExecuted = true
+        );
+
+        // Assert
+        wasExecuted.ShouldBeTrue();
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/RecoveryUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/RecoveryUnitTests.cs
@@ -1,0 +1,125 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class RecoveryUnitTests
+{
+    [Fact]
+    public void GetOrElse_WithValueFallback_WhenLeft_ShouldReturnFallback()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var value = either.GetOrElse(99);
+
+        // Assert
+        value.ShouldBe(99);
+    }
+
+    [Fact]
+    public void GetOrElse_WithDelegate_WhenLeft_ShouldUseLeftValue()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var value = either.GetOrElse(left => left.Length);
+
+        // Assert
+        value.ShouldBe(7);
+    }
+
+    [Fact]
+    public void GetOrElse_WhenRight_ShouldReturnRightValue()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act
+        var value = either.GetOrElse(99);
+
+        // Assert
+        value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void OrElse_WithLeftDependentFallback_WhenLeft_ShouldReturnFallback()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var recovered = either.OrElse(left => Either.Right<string, int>(left.Length));
+
+        // Assert
+        recovered.IsRight.ShouldBeTrue();
+        recovered.Match(left => left.Length, right => right).ShouldBe(7);
+    }
+
+    [Fact]
+    public void OrElse_WithParameterlessFallback_WhenLeft_ShouldReturnFallback()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act
+        var recovered = either.OrElse(() => Either.Right<string, int>(99));
+
+        // Assert
+        recovered.IsRight.ShouldBeTrue();
+        recovered.Match(left => left.Length, right => right).ShouldBe(99);
+    }
+
+    [Fact]
+    public void OrElse_WhenRight_ShouldReturnSameInstance()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+
+        // Act
+        var recovered = either.OrElse(() => Either.Right<string, int>(99));
+
+        // Assert
+        ReferenceEquals(either, recovered).ShouldBeTrue();
+        recovered.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+
+    [Fact]
+    public void OrElse_WhenRight_ShouldBeLazy()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+        var fallbackCallCount = 0;
+
+        // Act
+        var recovered = either.OrElse(() =>
+        {
+            fallbackCallCount++;
+            return Either.Right<string, int>(99);
+        });
+
+        // Assert
+        fallbackCallCount.ShouldBe(0);
+        recovered.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+
+    [Fact]
+    public void OrElse_WithLeftDependentFallback_WhenRight_ShouldBeLazy()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+        var fallbackCallCount = 0;
+
+        // Act
+        var recovered = either.OrElse(left =>
+        {
+            fallbackCallCount++;
+            return Either.Right<string, int>(left.Length);
+        });
+
+        // Assert
+        fallbackCallCount.ShouldBe(0);
+        recovered.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/RecoveryUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/RecoveryUnitTests.cs
@@ -44,6 +44,25 @@ public class RecoveryUnitTests
     }
 
     [Fact]
+    public void GetOrElse_WithDelegate_WhenRight_ShouldReturnRightValueWithoutInvokingFallback()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+        var fallbackCallCount = 0;
+
+        // Act
+        var value = either.GetOrElse(left =>
+        {
+            fallbackCallCount++;
+            return left.Length;
+        });
+
+        // Assert
+        fallbackCallCount.ShouldBe(0);
+        value.ShouldBe(42);
+    }
+
+    [Fact]
     public void OrElse_WithLeftDependentFallback_WhenLeft_ShouldReturnFallback()
     {
         // Arrange
@@ -58,6 +77,16 @@ public class RecoveryUnitTests
     }
 
     [Fact]
+    public void OrElse_WithLeftDependentFallback_WhenFallbackReturnsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => either.OrElse(_ => null!));
+    }
+
+    [Fact]
     public void OrElse_WithParameterlessFallback_WhenLeft_ShouldReturnFallback()
     {
         // Arrange
@@ -69,6 +98,16 @@ public class RecoveryUnitTests
         // Assert
         recovered.IsRight.ShouldBeTrue();
         recovered.Match(left => left.Length, right => right).ShouldBe(99);
+    }
+
+    [Fact]
+    public void OrElse_WithParameterlessFallback_WhenFallbackReturnsNull_ShouldThrow()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("missing");
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => either.OrElse(() => null!));
     }
 
     [Fact]

--- a/tests/Funcfy.Tests/MonadsTests/EitherTests/TapUnitTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/EitherTests/TapUnitTests.cs
@@ -1,0 +1,70 @@
+using Funcfy.Monads;
+
+namespace Funcfy.Tests.MonadsTests.EitherTests;
+
+public class TapUnitTests
+{
+    [Fact]
+    public void Tap_WhenRight_ShouldExecuteActionAndReturnSameInstance()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(21);
+        var observed = 0;
+
+        // Act
+        var tapped = either.Tap(value => observed = value * 2);
+
+        // Assert
+        observed.ShouldBe(42);
+        ReferenceEquals(either, tapped).ShouldBeTrue();
+        tapped.Match(left => left.Length, right => right).ShouldBe(21);
+    }
+
+    [Fact]
+    public void Tap_WhenLeft_ShouldNotExecuteAction()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+        var wasExecuted = false;
+
+        // Act
+        var tapped = either.Tap(_ => wasExecuted = true);
+
+        // Assert
+        wasExecuted.ShouldBeFalse();
+        ReferenceEquals(either, tapped).ShouldBeTrue();
+        tapped.Match(left => left, right => right.ToString()).ShouldBe("failure");
+    }
+
+    [Fact]
+    public void TapLeft_WhenLeft_ShouldExecuteActionAndReturnSameInstance()
+    {
+        // Arrange
+        var either = Either.Left<string, int>("failure");
+        string? observed = null;
+
+        // Act
+        var tapped = either.TapLeft(left => observed = left.ToUpperInvariant());
+
+        // Assert
+        observed.ShouldBe("FAILURE");
+        ReferenceEquals(either, tapped).ShouldBeTrue();
+        tapped.Match(left => left, right => right.ToString()).ShouldBe("failure");
+    }
+
+    [Fact]
+    public void TapLeft_WhenRight_ShouldNotExecuteAction()
+    {
+        // Arrange
+        var either = Either.Right<string, int>(42);
+        var wasExecuted = false;
+
+        // Act
+        var tapped = either.TapLeft(_ => wasExecuted = true);
+
+        // Assert
+        wasExecuted.ShouldBeFalse();
+        ReferenceEquals(either, tapped).ShouldBeTrue();
+        tapped.Match(left => left.Length, right => right).ShouldBe(42);
+    }
+}

--- a/tests/Funcfy.Tests/MonadsTests/ExtensionsTests/EmptyResultExtensionsTests/ToActionResultIntegrationTests.cs
+++ b/tests/Funcfy.Tests/MonadsTests/ExtensionsTests/EmptyResultExtensionsTests/ToActionResultIntegrationTests.cs
@@ -1,0 +1,103 @@
+using Funcfy.Monads;
+using Funcfy.Monads.Extensions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Funcfy.Tests.MonadsTests.ExtensionsTests.EmptyResultExtensionsTests;
+
+public class ToActionResultIntegrationTests
+{
+    public static TheoryData<Func<Result>, int, string> ErrorResults =>
+        new()
+        {
+            { () => Result.Create().WithBusinessError("Business rule failed"), StatusCodes.Status422UnprocessableEntity, "Business rule failed" },
+            { () => Result.Create().WithBadRequest("Invalid request"), StatusCodes.Status400BadRequest, "Invalid request" },
+            { () => Result.Create().WithUnauthorized("Authentication required"), StatusCodes.Status401Unauthorized, "Authentication required" },
+            { () => Result.Create().WithForbidden("Access denied"), StatusCodes.Status403Forbidden, "Access denied" },
+            { () => Result.Create().WithNotFound("Entity not found"), StatusCodes.Status404NotFound, "Entity not found" },
+            { () => Result.Create().WithConflict("State conflict"), StatusCodes.Status409Conflict, "State conflict" },
+            { () => Result.Create().WithServerError("Unexpected failure"), StatusCodes.Status500InternalServerError, "Unexpected failure" },
+            { () => Result.Create().WithServiceUnavailable("Dependency unavailable"), StatusCodes.Status503ServiceUnavailable, "Dependency unavailable" }
+        };
+
+    [Fact]
+    public async Task ToActionResult_WhenSuccessfulResultHasMessages_ShouldExecuteAsOkWithSerializedBody()
+    {
+        // Arrange
+        var result = Result.Success().WithInformation("Customer created", code: "CUSTOMER_CREATED");
+
+        // Act
+        var (statusCode, responseBody) = await ExecuteAsync(result.ToActionResult());
+
+        // Assert
+        statusCode.ShouldBe(StatusCodes.Status200OK);
+        responseBody.ShouldContain("Customer created");
+        responseBody.ShouldContain("CUSTOMER_CREATED");
+    }
+
+    [Fact]
+    public async Task ToActionResult_WhenSuccessfulResultHasNoMessages_ShouldExecuteAsNoContent()
+    {
+        // Arrange
+        var result = Result.Success();
+
+        // Act
+        var (statusCode, responseBody) = await ExecuteAsync(result.ToActionResult());
+
+        // Assert
+        statusCode.ShouldBe(StatusCodes.Status204NoContent);
+        responseBody.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(ErrorResults))]
+    public async Task ToActionResult_WhenResultFailed_ShouldExecuteWithExpectedErrorStatusCodeAndSerializedBody(
+        Func<Result> resultFactory,
+        int expectedStatusCode,
+        string expectedMessage)
+    {
+        // Arrange
+        var result = resultFactory();
+
+        // Act
+        var (statusCode, responseBody) = await ExecuteAsync(result.ToActionResult());
+
+        // Assert
+        statusCode.ShouldBe(expectedStatusCode);
+        responseBody.ShouldContain(expectedMessage);
+    }
+
+    private static async Task<(int StatusCode, string ResponseBody)> ExecuteAsync(IActionResult actionResult)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        await using var responseBody = new MemoryStream();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider,
+            Response =
+            {
+                Body = responseBody
+            }
+        };
+
+        var actionContext = new ActionContext(
+            httpContext,
+            new RouteData(),
+            new ActionDescriptor()
+        );
+
+        await actionResult.ExecuteResultAsync(actionContext);
+
+        responseBody.Position = 0;
+        using var reader = new StreamReader(responseBody);
+        return (httpContext.Response.StatusCode, await reader.ReadToEndAsync());
+    }
+}


### PR DESCRIPTION
### Added

- Introduced `Either<TLeft, TRight>` as a first-class right-biased monad with `Left`/`Right` factories, `Match`, `Map`, `MapLeft`, `Bind`, recovery helpers, and side-effect helpers.
- Added `Either` conversion helpers for `Maybe<T>` and one-way conversion to `Result<T>`.
- Integration-style ASP.NET Core coverage for `Result.ToActionResult()` execution.
- Additional service-layer and controller-layer examples for `Maybe<T>`, `Result`, and ASP.NET Core usage.

### Changed

- Replaced legacy ASP.NET Core MVC package references with the .NET 8 shared framework reference.
- Updated documentation navigation so examples, roadmap, and release notes are easier to find.

### Fixed

- Added automated coverage for `Either` branch equality, monad laws, lazy fallback behavior, and delegate guard clauses.

### Documentation

- Added `CHANGELOG.md` and linked it from the root README and docs index.
- Added `Either` documentation and surfaced it in the root README and docs index.